### PR TITLE
fix scrapy command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ cd scraping/spiders
 
 * Scraper les liens vers chaque discours et les stocker dans un JSON
 ```
-scrapy runspider speechlinks_spider.py links.json
+scrapy runspider speechlinks_spider.py --output links.json
 ```
 
 * Scraper les discours en entier via leurs liens
 ```
-scrapy runspider speech_spider.py speeches.json
+scrapy runspider speech_spider.py --output speeches.json
 ```
 
 ### Modèle


### PR DESCRIPTION
## Overview
When I try to download speech from website by using commands like:
```sh
$ scrapy runspider speechlinks_spider.py links.json
```
I just obtain the scrapy runspider help message.
You need to specify the output file for fix this behavior:

```sh
$ scrapy runspider speechlinks_spider.py --output links.json
```
This merge request fix documentation.