### PR TITLE
fix encoding for python 2.x

### DIFF
--- a/data.py
+++ b/data.py
@@ -1,3 +1,4 @@
+#! -*-coding:utf8-*-
 from params import LOCAL_PATH, SEQ_LEN, SEQ_SKIP, PRED_START_INDEX
 from processing import get_alphabet, create_dicts, encode, create_data
 

--- a/network.py
+++ b/network.py
@@ -1,3 +1,4 @@
+#! -*-coding:utf8-*-
 import tensorflow as tf
 import keras.backend as K
 from keras.models import Sequential, load_model

--- a/params.py
+++ b/params.py
@@ -1,3 +1,4 @@
+#! -*-coding:utf8-*-
 # Paramètres de prétraitement
 LOCAL_PATH = "candidats.txt"
 SEQ_LEN = 50

--- a/prediction.py
+++ b/prediction.py
@@ -1,3 +1,4 @@
+#! -*-coding:utf8-*-
 from keras.models import Sequential, load_model
 import numpy as np
 import argparse

--- a/scraping/extract_text.py
+++ b/scraping/extract_text.py
@@ -1,3 +1,4 @@
+#!-*-coding:utf8-*-
 import json
 import pandas as pd
 import numpy as np


### PR DESCRIPTION
## Overview
Set encoding to use for fix python 2.x usages.

When shebang encoding was not specified the following error occur:
```shell
$ python network.py -m scraping/spiders/speeches.json 
File "network.py", line 11
SyntaxError: Non-ASCII character '\xc3' in file network.py on line 11, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

```